### PR TITLE
ft: share http sesion, tqdm progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ This is useful for when a student knows the courses they wish to take, and wants
 
 ## How to update
 
-Run write_raw.py in the util folder. It is recommended to use a sleep interval of at least a few seconds to not flood http requests. You should see a list of failures, please note them down so they can be tracked. Afterwards, run make_local_db script. This will update the actual .db that is queried. You can then run the flask app and check that classes were added, updated (prof info), or removed. We only track current and future terms.
+Run `scrape.py` in the [util]() folder.
+The Catalogue site changes the HTML occasionally,
+and usually this is the file that will need correcting if that's the case.
+This will scrape all the courses listed on the catalogue,
+and generate a `raw.json` which contains characterizing information for each course instance. Afterward, run `make_local_db.py` to create the SQLite DB the backend queries.
+
+
+You can then run the flask app and check that classes were added, updated (prof info), or removed.
+We only track current and future terms.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This program is the server back-end of [schedubuddy](https://schedubuddy.com/), 
 This codebase handles the construction of a local database which it then uses itself.
 Raw data is processed to generate several schedules for a queried list of courses, and then ranked and filtered according to user preferences.
 This is useful for when a student knows the courses they wish to take, and wants to create an optimal schedule.
+Minimum supported Python version is 3.10
 
 ## How to update
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-ldap3
 Flask
-ortools
 Flask_Compress
 Flask_Cors
-requests
+Pillow==9.5.0
 beautifulsoup4
 gunicorn
-python-dateutil
 lxml
+ortools
+python-dateutil
 pytz
-Pillow==9.5.0
+requests
+tqdm

--- a/util/scrape.py
+++ b/util/scrape.py
@@ -341,8 +341,14 @@ def main(args):
     logger.setLevel(logging.DEBUG if debug else logging.INFO)
     logger.debug("debug mode is active")
     logger.debug(f"{args=}")
-    cache_ttl_text = str(timedelta(seconds=args.cache_ttl * 60)) if args.cache_ttl > 0 else "infinite"
-    logger.info(f"max_workers={args.max_workers} cache_ttl=({timedelta(seconds=args.cache_ttl * 60)})")
+    cache_ttl_text = (
+        str(timedelta(seconds=args.cache_ttl * 60))
+        if args.cache_ttl > 0
+        else "infinite"
+    )
+    logger.info(
+        f"max_workers={args.max_workers} cache_ttl=(cache_ttl_text)"
+    )
     root = Path(args.scrape_root).absolute()
     scraper = Scraper(
         cache_dir=root / ".cache",

--- a/util/scrape.py
+++ b/util/scrape.py
@@ -348,7 +348,7 @@ def cli():
         action="store_true",
         help="uses processes instead of threads for the parallel compute implementation. "
         "This is only recommended when you know most things you are going to access will be cached, "
-        "as this disables sharing HTTP sessions.",
+        "as this disables sharing HTTP sessions. Higher -j reccomended in conjunction with this flag",
     )
     args = parser.parse_args()
     main(args)

--- a/util/scrape.py
+++ b/util/scrape.py
@@ -294,7 +294,7 @@ class Scraper:
         else:
             partial_tqdm = lambda x: x
         result = []
-        with futures.ThreadPoolExecutor(max_workers=self.max_workers) as exe:
+        with futures.ProcessPoolExecutor(max_workers=self.max_workers) as exe:
             # map the future to the subject, that way we can tell what subject failed
             fut_to_input = {exe.submit(fn, x): x for x in input_data}
 

--- a/util/scrape.py
+++ b/util/scrape.py
@@ -294,7 +294,7 @@ class Scraper:
         else:
             partial_tqdm = lambda x: x
         result = []
-        with futures.ProcessPoolExecutor(max_workers=self.max_workers) as exe:
+        with futures.ThreadPoolExecutor(max_workers=self.max_workers) as exe:
             # map the future to the subject, that way we can tell what subject failed
             fut_to_input = {exe.submit(fn, x): x for x in input_data}
 

--- a/util/scrape.py
+++ b/util/scrape.py
@@ -348,7 +348,7 @@ def cli():
         action="store_true",
         help="uses processes instead of threads for the parallel compute implementation. "
         "This is only recommended when you know most things you are going to access will be cached, "
-        "as this disables sharing HTTP sessions. Higher -j reccomended in conjunction with this flag",
+        "as this disables sharing HTTP sessions. Higher -j recommended in conjunction with this flag",
     )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
add progress bar via tqdm. shows speed, ETA
```
....
2023-10-16 01:19:24,096 [INFO]: processing 9794 courses
  8%|▊         | 828/9.79k [00:35<06:39, 22.5course/s]
```
share http session: less time wasted on TLS
```
3 thread: 18 courses/s
3 thread, shared session: 63 courses/s
8 thread, shared session: 120 courses/s
8 thread, infinite ttl (ie file IO only): 137 courses/s
```
add --use-processes flag: when this is specified, ProcessPoolExecutor is used instead of ThreadPoolExecutor. This allows us to a lot more GIL-blocked paralell computation, but should only be used when doing minimal requests because we lose the shared HTTP session benefits. `scrape -j 12 --use-processes` ~2.5kc/s

